### PR TITLE
fix: close scoped prototype-pollution in merge/assign else-branch

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -85,11 +85,11 @@ function baseMerger<B extends MergerSource[]>(
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i] as (keyof MergerSourceUnwrap<B>);
 
-            if (hasOwnProperty(target, key)) {
-                if (!isSafeKey(key as string)) {
-                    continue;
-                }
+            if (!isSafeKey(key as string)) {
+                continue;
+            }
 
+            if (hasOwnProperty(target, key)) {
                 if (context.options.strategy) {
                     const applied = context.options.strategy(target, key as string, source[key]);
                     if (typeof applied !== 'undefined') {

--- a/test/unit/module.spec.ts
+++ b/test/unit/module.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createMerger, merge } from '../../src';
+import { assign, createMerger, merge } from '../../src';
 
 class MyCircularClass {
     ref : MyCircularClass;
@@ -191,7 +191,42 @@ describe('src/module/*.ts', () => {
     it('should not merge unsafe key', () => {
         const merger = createMerger({ priority: 'right' });
         const merged = merger({ prototype: null }, { prototype: 1 });
-        expect(merged).toEqual({ prototype: 1 });
+        expect(Object.hasOwn(merged as object, 'prototype')).toBe(false);
+    });
+
+    it('should not pollute prototype via __proto__ key when target lacks that own key', () => {
+        const payload = JSON.parse('{"__proto__":{"isAdmin":true,"role":"admin"}}');
+        const result = merge({ name: 'guest' }, payload) as Record<string, any>;
+
+        expect(Object.hasOwn(result, 'isAdmin')).toBe(false);
+        expect(result.isAdmin).toBeUndefined();
+        expect(result.role).toBeUndefined();
+        expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+        expect(({} as Record<string, any>).isAdmin).toBeUndefined();
+    });
+
+    it('should not pollute prototype of in-place target via __proto__ key', () => {
+        const target : Record<string, any> = { x: 1 };
+        assign(target, JSON.parse('{"__proto__":{"polluted":"YES"}}'));
+
+        expect(target.polluted).toBeUndefined();
+        expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+    });
+
+    it('should not propagate __proto__ pollution into nested merges', () => {
+        const payload = JSON.parse('{"sub":{"__proto__":{"poll":"DEEP"}}}');
+        const result = merge({ sub: { a: 1 } }, payload) as Record<string, any>;
+
+        expect(result.sub.poll).toBeUndefined();
+        expect(Object.getPrototypeOf(result.sub)).toBe(Object.prototype);
+    });
+
+    it('should reject constructor and prototype keys when target lacks them as own props', () => {
+        const result = merge({}, JSON.parse('{"constructor":1,"prototype":2}')) as Record<string, any>;
+
+        expect(Object.hasOwn(result, 'constructor')).toBe(false);
+        expect(Object.hasOwn(result, 'prototype')).toBe(false);
+        expect(result.constructor).toBe(Object.prototype.constructor);
     });
 
     it('should return optimized return type', () => {


### PR DESCRIPTION
## Summary

`baseMerger` only consulted `isSafeKey` inside the `hasOwnProperty(target, key)` branch. The `else` branch — taken when `target` does not already have the key as an own property, i.e. the headline `merge(defaults, req.body)` call site — wrote `source[key]` into `target` via `Object.assign(target, { [key]: source[key] })` with no key filter.

For a payload like `JSON.parse('{"__proto__":{"isAdmin":true}}')`:

1. `Object.keys(source)` returns the string `"__proto__"` (`JSON.parse` creates an own enumerable property with that literal name).
2. `Object.assign(target, { __proto__: source.__proto__ })` invokes the `__proto__` accessor on `target` per ECMAScript spec rather than performing an own-property write.
3. The returned merged object's prototype is replaced with the attacker-controlled value; subsequent property reads (`merged.isAdmin`) walk the polluted prototype.

Pollution is **scoped** to the returned (or in-place) target — `Object.prototype` is not modified globally — but it still breaks the "safe merge" contract the package advertises. Same class as **CVE-2022-24802** (deepmerge-ts, 8.1 High) and **CVE-2024-38986** (@75lb/deep-merge, 8.1 High).

## Fix

Hoist `isSafeKey(key)` above the `if (hasOwnProperty(target, key))` branch split in `src/module.ts`. The unsafe keys (`__proto__`, `prototype`, `constructor`) are rejected uniformly before either path runs.

```diff
 const keys = Object.keys(source);
 for (let i = 0; i < keys.length; i++) {
     const key = keys[i] as (keyof MergerSourceUnwrap<B>);

-    if (hasOwnProperty(target, key)) {
-        if (!isSafeKey(key as string)) {
-            continue;
-        }
+    if (!isSafeKey(key as string)) {
+        continue;
+    }

+    if (hasOwnProperty(target, key)) {
         if (context.options.strategy) {
```

## Tests

Four new regression tests in `test/unit/module.spec.ts`:

- `should not pollute prototype via __proto__ key when target lacks that own key` — the headline `merge(defaults, body)` case.
- `should not pollute prototype of in-place target via __proto__ key` — covers `assign()`.
- `should not propagate __proto__ pollution into nested merges` — recursive case.
- `should reject constructor and prototype keys when target lacks them as own props` — sibling vectors.

The pre-existing `should not merge unsafe key` test implicitly relied on the buggy else-branch behavior (it expected the unsafe key to flow through). Its assertion is updated to require the key be rejected.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run test` — 4 files, **28/28** tests pass (was 24/24 + 4 new regression tests).
- [x] `npm run build` — emits both ESM and CJS at unchanged paths.
- [x] PoC reproduced against pre-fix `dist/index.mjs` (all four scenarios trigger, including `*** AUTH BYPASS ***`). PoC no longer reproduces after the patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge security by filtering unsafe property keys earlier in the merge process to prevent prototype pollution vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/smob/pull/446)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->